### PR TITLE
feat: use package.json for test to test plugin loading

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
       with:
         node-version: 16
     - run: npm install
+    - run: npm install
+      working-directory: ./test/integration
     - run: |
         npm run test
-        $LASTEXITCODE

--- a/test/integration/package-lock.json
+++ b/test/integration/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "index.test",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "index.test",
+      "devDependencies": {
+        "httpyac-plugin-yaml-body": "../.."
+      }
+    },
+    "../..": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yaml": "^1.10.2"
+      },
+      "devDependencies": {
+        "httpyac": "^4.7.3",
+        "jest": "^27.4.3",
+        "mockttp": "^2.4.0"
+      }
+    },
+    "node_modules/httpyac-plugin-yaml-body": {
+      "resolved": "../..",
+      "link": true
+    }
+  },
+  "dependencies": {
+    "httpyac-plugin-yaml-body": {
+      "version": "file:../..",
+      "requires": {
+        "httpyac": "^4.7.3",
+        "jest": "^27.4.3",
+        "mockttp": "^2.4.0",
+        "yaml": "^1.10.2"
+      }
+    }
+  }
+}

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "index.test",
+  "private": true,
+  "devDependencies": {
+    "httpyac-plugin-yaml-body": "../.."
+  }
+}

--- a/test/integration/test.http
+++ b/test/integration/test.http
@@ -1,8 +1,3 @@
-{{
-  const plugin = require("../../src/index");
-  plugin(httpFile);
-}}
-
 ### withYaml
 POST http://localhost:8080
 ---


### PR DESCRIPTION
Here is my attempt to solve it using package.json. Advantage is the correct loading by means of my plugin logic. The disadvantage is that an `npm i` must be done in the `/test/integration` folder

Just a warning: I have changed the Github Action to call `npm i` in test folder